### PR TITLE
`Routes` criado para cobrir todas as rotas da api

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.4",
   "description": "This is a unofficial package of Discloud API",
   "scripts": {
-    "build": "npx tsc",
+    "build": "tsc",
     "dev": "npx tsnd --respawn --transpile-only test.ts",
     "tscd": "npx tsc --declaration"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.4",
   "description": "This is a unofficial package of Discloud API",
   "scripts": {
-    "build": "tsc",
+    "build": "npx tsc",
     "dev": "npx tsnd --respawn --transpile-only test.ts",
     "tscd": "npx tsc --declaration"
   },

--- a/packages/Routes/App.ts
+++ b/packages/Routes/App.ts
@@ -1,0 +1,83 @@
+export const App = new class App {
+  /**
+   * - GET - `/app/${appID}`
+   */
+  app<appID extends string>(appID: appID): `/app/${appID}` {
+    return `/app/${appID}`
+  }
+
+  /**
+   * - GET - `/app/${appID}/backup`
+   */
+  backup<appID extends string>(appID: appID): `/app/${appID}/backup` {
+    return `/app/${appID}/backup`
+  }
+
+  /**
+   * - PUT - `/app/${appID}/commit`
+   */
+  commit<appID extends string>(appID: appID): `/app/${appID}/commit` {
+    return `/app/${appID}/commit`
+  }
+
+  /**
+   * - DELETE - `/app/${appID}/delete`
+   */
+  delete<appID extends string>(appID: appID): `/app/${appID}/delete` {
+    return `/app/${appID}/delete`
+  }
+
+  /**
+   * - GET - `/app/${appID}/logs`
+   */
+  logs<appID extends string>(appID: appID): `/app/${appID}/logs` {
+    return `/app/${appID}/logs`
+  }
+
+  /**
+   * - PUT - `/app/${appID}/ram`
+   */
+  ram<appID extends string>(appID: appID): `/app/${appID}/ram` {
+    return `/app/${appID}/ram`
+  }
+
+  /**
+   * - PUT - `/app/${appID}/restart`
+   */
+  restart<appID extends string>(appID: appID): `/app/${appID}/restart` {
+    return `/app/${appID}/restart`
+  }
+
+  /**
+   * - PUT - `/app/${appID}/start`
+   */
+  start<appID extends string>(appID: appID): `/app/${appID}/start` {
+    return `/app/${appID}/start`
+  }
+
+  /**
+   * - GET - `/app/${appID}/status`
+   */
+  status<appID extends string>(appID: appID): `/app/${appID}/status` {
+    return `/app/${appID}/status`
+  }
+
+  /**
+   * - PUT - `/app/${appID}/stop`
+   */
+  stop<appID extends string>(appID: appID): `/app/${appID}/stop` {
+    return `/app/${appID}/stop`
+  }
+
+  /**
+   * - GET - `/app/${appID}/team`
+   * - POST - `/app/${appID}/team`
+   * - PUT - `/app/${appID}/team`
+   * - DELETE - `/app/${appID}/team/${modID}`
+   */
+  team<appID extends string>(appID: appID): `/app/${appID}/team`
+  team<appID extends string, modID extends string>(appID: appID, modID: modID): `/app/${appID}/team/${modID}`
+  team<appID extends string, modID extends string>(appID: appID, modID?: modID) {
+    return modID ? `/app/${appID}/team/${modID}` : `/app/${appID}/team`
+  }
+}

--- a/packages/Routes/RouteBases.ts
+++ b/packages/Routes/RouteBases.ts
@@ -1,0 +1,3 @@
+export const RouteBases = new class RouteBases {
+  api = 'https://api.discloud.app/v2'
+}

--- a/packages/Routes/Team.ts
+++ b/packages/Routes/Team.ts
@@ -1,0 +1,43 @@
+export const Team = new class Team {
+  /**
+   * - GET - `/team`
+   */
+  team(): '/team' {
+    return '/team'
+  }
+
+  /**
+   * - GET - `/app/${appID}/backup`
+   */
+  backup<appID extends string>(appID: appID): `/team/${appID}/backup` {
+    return `/team/${appID}/backup`
+  }
+
+  /**
+   * - PUT - `/app/${appID}/commit`
+   */
+  commit<appID extends string>(appID: appID): `/team/${appID}/commit` {
+    return `/team/${appID}/commit`
+  }
+
+  /**
+   * - PUT - `/app/${appID}/restart`
+   */
+  restart<appID extends string>(appID: appID): `/team/${appID}/restart` {
+    return `/team/${appID}/restart`
+  }
+
+  /**
+   * - PUT - `/app/${appID}/start`
+   */
+  start<appID extends string>(appID: appID): `/team/${appID}/start` {
+    return `/team/${appID}/start`
+  }
+
+  /**
+   * - PUT - `/app/${appID}/stop`
+   */
+  stop<appID extends string>(appID: appID): `/team/${appID}/stop` {
+    return `/team/${appID}/stop`
+  }
+}

--- a/packages/Routes/Upload.ts
+++ b/packages/Routes/Upload.ts
@@ -1,0 +1,8 @@
+export const Upload = new class Upload {
+  /**
+ * - POST - `/upload`
+ */
+  upload(): '/upload' {
+    return '/upload'
+  }
+}

--- a/packages/Routes/User.ts
+++ b/packages/Routes/User.ts
@@ -1,0 +1,8 @@
+export const User = new class User {
+  /**
+ * - GET - `/user`
+ */
+  user(): '/user' {
+    return '/user'
+  }
+}

--- a/packages/Routes/index.ts
+++ b/packages/Routes/index.ts
@@ -1,0 +1,34 @@
+import { App } from './App'
+import { Team } from './Team'
+import { Upload } from './Upload'
+import { User } from './User'
+
+export * from './RouteBases'
+
+export const Routes = new class Routes {
+  /** app */
+  app = App.app
+  appBackup = App.backup
+  appCommit = App.commit
+  appDelete = App.delete
+  appLogs = App.logs
+  appRam = App.ram
+  appRestart = App.restart
+  appStart = App.start
+  appStatus = App.status
+  appStop = App.stop
+
+  /** team */
+  team = Team.team
+  teamBackup = Team.backup
+  teamCommit = Team.commit
+  teamRestart = Team.restart
+  teamStart = Team.start
+  teamStop = Team.stop
+
+  /** upload */
+  upload = Upload.upload
+
+  /** user */
+  user = User.user
+}


### PR DESCRIPTION
Para cobrir todas as rotas da api facilmente

assim pode-se escrever

```ts
axios.get(Routes.app("ID"), {
  baseUrl: RouteBases.api,
})
```

ao invés de

```ts
axios.get(`/app/${"ID"}`, {
  baseURL: 'https://api.discloud.app/v2',
})
```